### PR TITLE
Add support for a custom PClassInfo2 category

### DIFF
--- a/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST3.cpp
+++ b/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST3.cpp
@@ -4208,7 +4208,11 @@ private:
 
         static const PClassInfo2 componentClass { JuceVST3Component::iid,
                                                   PClassInfo::kManyInstances,
+#ifdef SPLICE_STUDIO_ONE_INTEGRATION_ENABLED
+                                                  "Media Content Provider",
+#else
                                                   kVstAudioEffectClass,
+#endif
                                                   JucePlugin_Name,
                                                   JucePlugin_Vst3ComponentFlags,
                                                   JucePlugin_Vst3Category,


### PR DESCRIPTION
Optionally override the VST PClassInfo2 category for the processor to use a custom category.