### PR TITLE
Don't resize the host window for media content providers

### DIFF
--- a/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST3.cpp
+++ b/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST3.cpp
@@ -2193,6 +2193,10 @@ private:
 
             void resizeHostWindow()
             {
+#ifdef JUCE_VST3_MEDIA_CONTENT_PROVIDER
+                // Don't dictate the host window size for media content providers
+                return;
+#endif
                 if (pluginEditor != nullptr)
                 {
                     if (owner.plugFrame != nullptr)


### PR DESCRIPTION
For media content providers, we expect the host to determine the plugin's size at all times.