### PR TITLE
set a null host on plugin terminate

### DIFF
--- a/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST3.cpp
+++ b/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST3.cpp
@@ -783,6 +783,13 @@ public:
         if (auto* pluginInstance = getPluginInstance())
             pluginInstance->removeListener (this);
 
+        if (audioProcessor)
+        {
+            if (auto* extensions = audioProcessor->get()->getVST3ClientExtensions())
+            {
+                extensions->setIHostApplication(nullptr);
+            }
+        }
         audioProcessor = nullptr;
 
         return EditController::terminate();


### PR DESCRIPTION
Some hosts expect plugins to clean up their extensions on `terminate()`, rather than on plugin destruction. This change passes `nullptr` as the host on `terminate()` to give the VST3 extensions a chance to clean up (e.g. un-registering handlers)